### PR TITLE
Issue4-s3bucketname

### DIFF
--- a/CloudFormation/vpc/freetier/ec2.cf
+++ b/CloudFormation/vpc/freetier/ec2.cf
@@ -1,6 +1,10 @@
-# The OA
 
 Parameters:
+
+  FtS3BucketNameParameter:
+    Description: s3 bucket to get deploys from.
+    Type: String
+    Default: change-to-your-ft-bucket-name
 
   InstanceTypeParameter:
     Description: t2.micro(1c,1g) t2.small(1c,2g) t3.micro(2c,1g) t3.small(2c,2g). Default is t3.small.
@@ -184,7 +188,7 @@ Resources:
         "Fn::Base64":
             "Fn::Sub": |
               #!/bin/bash
-              aws s3 cp s3://ll-ig-oa/${DeployNameParameter} - | bash -s
+              aws s3 cp s3://${FtS3BucketNameParameter}/${DeployNameParameter} - | bash -s
 
 # How to get and allocate a "new" EIP and associate it to an instance
   EC2InstanceEIP:
@@ -222,19 +226,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: 's3:ListBucket'
-                Resource: 'arn:aws:s3:::ll-ig-oa'
+                Resource: !Join ['', ['arn:aws:s3:::', !Ref "FtS3BucketNameParameter"]]
               - Effect: Allow
                 Action:
                   - 's3:PutObject'
                   - 's3:GetObject'
                   - 's3:DeleteObject'
-                Resource: 'arn:aws:s3:::ll-ig-oa/openarenaeplus/server.cfg'
-              - Effect: Allow
-                Action:
-                  - 's3:PutObject'
-                  - 's3:GetObject'
-                  - 's3:DeleteObject'
-                Resource: 'arn:aws:s3:::ll-ig-oa/openarenaeplus/deploy.sh'
+                Resource: !Join ['', ['arn:aws:s3:::', !Ref "FtS3BucketNameParameter",'/*']]
 
   EC2S3RoleInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/CloudFormation/vpc/freetier/s3.cf
+++ b/CloudFormation/vpc/freetier/s3.cf
@@ -1,6 +1,26 @@
+Parameters:
+  s3BucketNameParameter:
+    Description: Choose a globally unique name. Bucket names must be between 3 and 63 characters long.
+                 Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).
+                 Bucket names must begin and end with a letter or number.
+    Type: String
+    Default: change-me
+
 Resources:
-  TheOaS3Bucket:
+  s3Bucket:
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain
     Properties:
-      BucketName: ll-ig-oa
+      BucketName: !Ref s3BucketNameParameter
+
+Outputs:
+  s3BucketNameOutput:
+    Value: !Ref s3Bucket
+    Description: S3 Bucket Name
+    Export:
+      Name: !Sub ${AWS::StackName}-s3BucketNameOutput
+  s3BucketArnOutput:
+    Value: !GetAtt Arn
+    Description: s3 bucket Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-s3BucketArnOutput


### PR DESCRIPTION
I removed hard coding of bucket name for both bucket creation stack and the deploy stack.  I think for the future we might consider putting the "bootstrap" bucket name into SSM and getting it from SSM so the user doesn't need to input it when deploying, maybe? Out of scope for now. 

These changes will allow you to deploy from scratch without the hardcoded bucket name getting in the way. 