### PR TITLE
issue#7 make r53 generic

### DIFF
--- a/CloudFormation/vpc/freetier/ec2.cf
+++ b/CloudFormation/vpc/freetier/ec2.cf
@@ -29,6 +29,11 @@ Parameters:
       - openarena/deploy.sh
       - openarenaeplus/deploy.sh
 
+  HostNameParamter:
+    Description: Enter the host name of your instance.
+    Type: String
+    Default: myhost
+
 # Mappings... proof of concept, specify the "OS code"
 # and get the image based on the region you are deploying in
 # use it as a parameter for EC2 like:
@@ -244,8 +249,8 @@ Resources:
   EC2InstanceRecordSetA:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId: !ImportValue IgCloudynetworkZoneExport
-      Name: oa.ig.cloudynet.work.
+      HostedZoneId: !ImportValue HostedZone1IdExport
+      Name: !Join ['', [!Ref "HostNameParamter", ".", !ImportValue HostedZone1ParameterExport, '.']]
       Type: A
       TTL: '60'
       ResourceRecords:

--- a/CloudFormation/vpc/freetier/r53.cf
+++ b/CloudFormation/vpc/freetier/r53.cf
@@ -1,30 +1,38 @@
-
+Parameters:
+  HostedZone1Parameter:
+    Type: String
+    Description: Enter your domain or subdomain.
 
 Resources:
-  IgCloudynetWorkZone:
+  HostedZone1:
     Type: "AWS::Route53::HostedZone"
     Properties:
       HostedZoneConfig:
-        Comment: "Public hosted zone for ig.cloudynet.work"
-      Name: ig.cloudynet.work.
+        Comment: !Ref HostedZone1Parameter
+      Name: !Ref HostedZone1Parameter
 
 # Example of a statically defined host record
-#  TheOA:
+#  HostedZone1:
 #    Type: AWS::Route53::RecordSet
 #    Properties:
-#      HostedZoneName: cloudynet.work.
-#      Name: oa.ig.cloudynet.work.
+#      HostedZoneName: domain.tld.
+#      Name: host.domain.tld.
 #      Type: A
 #      TTL: '60'
 #      ResourceRecords:
 #      - 54.176.172.49
-#    DependsOn: CloudynetWorkZone
+#    DependsOn: HostedZone1
 
 # Using Outputs we can get the name of the zone to import in another stack
 # This is how I was able to make a host record from another stack
 Outputs:
-  IgCloudynetWorkZoneExport:
+  HostedZone1IdExport:
     Description: The hosted zone id
-    Value: !Ref IgCloudynetWorkZone
+    Value: !Ref HostedZone1
     Export:
-      Name: "IgCloudynetworkZoneExport"
+      Name: "HostedZone1IdExport"
+  HostedZone1ParameterExport:
+    Description: The hosted zone Name parameter
+    Value: !Ref HostedZone1Parameter
+    Export:
+      Name: "HostedZone1ParameterExport"


### PR DESCRIPTION
allow users to input both hosted zone name and hostname. I have added the 
"HostedZone1Parameter" and "HostNameParamter" and make the resource name 
more generic.

with this change a user can deploy the stack in a fresh account, assuming bootstrap steps have been followed, without any changes to the CF code required... I think...  I took some notes here:

https://gist.github.com/russelltadams/e3b7ffc45b5dfc5f1071ea5d66150c63